### PR TITLE
chore(deps): bump node from 20-alpine to 22-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Upgrade Docker build stage from Node 20 to Node 22 LTS
- Aligns Docker with CI workflow (which uses Node 22)
- Node 22 is Active LTS until Oct 2025, providing stability

Closes the more aggressive Node 25 upgrade from Dependabot in favor of LTS.

## Test plan
- [ ] CI build passes
- [ ] Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)